### PR TITLE
Rename application types directory in setup script

### DIFF
--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -26,7 +26,7 @@ content=$(find . -type f \( \
 
 # The identifiers above will be replaced in the path of the files and directories found here
 paths=$(find . -depth 2 \( \
-  -path "…" \
+  -path "./types/${kebabCaseBefore}" \
 \))
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The folder was still named `./types/ember-boilerplate` after running the `boilerplate-setup.sh` script.