### PR TITLE
Do not freeze patch version for Node and NPM requirements

### DIFF
--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -22,8 +22,8 @@
 
 ## 🚧 Dependencies
 
-- Node.js (`10.15.1`)
-- NPM (`6.4.1`)
+- Node.js (`~> 10.15`)
+- NPM (`~> 6.4`)
 
 ## 🏎 Kickstart
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ lint: lint-prettier lint-eslint lint-tslint lint-stylelint lint-template-lint ##
 
 .PHONY: lint-prettier
 lint-prettier:
-	npx prettier -l ember-cli-build.js testem.js '{app,tests,config,service-worker}/**/*.{ts,js,graphql,scss}' '**/*.md'
+	npx prettier -l ember-cli-build.js testem.js '{app,tests,config,scripts,service-worker}/**/*.{ts,js,graphql,scss}' '**/*.md'
 
 .PHONY: lint-eslint
 lint-eslint:
@@ -73,7 +73,7 @@ format: format-prettier format-svgo ## Run formatting tools on the code
 
 .PHONY: format-prettier
 format-prettier:
-	npx prettier --write ember-cli-build.js testem.js '{app,tests,config,service-worker}/**/*.{ts,js,graphql,scss}' '**/*.md'
+	npx prettier --write ember-cli-build.js testem.js '{app,tests,config,scripts,service-worker}/**/*.{ts,js,graphql,scss}' '**/*.md'
 
 .PHONY: format-svgo
 format-svgo:

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "prestart": "npm run enforce-engine-versions"
   },
   "repository": "https://github.com/mirego/ember-boilerplate",
+  "engine-strict": true,
   "engines": {
-    "node": "10.15.1",
-    "npm": "6.4.1"
+    "node": "~10.15",
+    "npm": "~6.4"
   },
   "dependencies": {
     "@ember-decorators/argument": "1.0.0-beta.2",

--- a/scripts/enforce-engine-versions.js
+++ b/scripts/enforce-engine-versions.js
@@ -4,22 +4,45 @@
 /* eslint-disable no-console */
 
 let exitStatus = 0;
+let semver;
 
-const {node: expectedNodeVersion, npm: expectedNpmVersion} = require('../package.json').engines;
+try {
+  semver = require('semver');
+} catch {
+  // The `semver` might not be available since we run this
+  // script as a `preinstall` hook.
+  console.info(
+    'Skipping “enforce-engine-versions” script because `semver` module is not available.'
+  );
+  process.exit(exitStatus);
+}
+
+const {
+  node: expectedNodeVersion,
+  npm: expectedNpmVersion
+} = require('../package.json').engines;
 const actualNodeVersion = process.versions.node;
-const actualNpmVersion = require('child_process').execSync('npm -v').toString().replace(/\n/, '');
+
+const actualNpmVersion = require('child_process')
+  .execSync('npm -v')
+  .toString()
+  .replace(/\n/, '');
 
 console.info(`Node.js ${actualNodeVersion}`);
 console.info(`NPM ${actualNpmVersion}`);
 console.info('');
 
-if (expectedNodeVersion !== actualNodeVersion) {
-  console.error(`You are using Node.js ${actualNodeVersion} but the required version specified in package.json is ${expectedNodeVersion}`);
+if (!semver.satisfies(actualNodeVersion, expectedNodeVersion)) {
+  console.error(
+    `You are using Node.js ${actualNodeVersion} but the required version specified in package.json is ${expectedNodeVersion}`
+  );
   exitStatus = 1;
 }
 
-if (expectedNpmVersion !== actualNpmVersion) {
-  console.error(`You are using NPM ${actualNpmVersion} but the required version specified in package.json is ${expectedNpmVersion}`);
+if (!semver.satisfies(actualNpmVersion, expectedNpmVersion)) {
+  console.error(
+    `You are using NPM ${actualNpmVersion} but the required version specified in package.json is ${expectedNpmVersion}`
+  );
   exitStatus = 1;
 }
 


### PR DESCRIPTION
Like we did in https://github.com/mirego/elixir-boilerplate/pull/15, we now require `node ~> 10.15` (not `node = 10.15.1`) and `npm ~> 6.4` (not `npm = 6.4.1`).