### PR TITLE
Add home route

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "stylelint-config-mirego"
+  "extends": "stylelint-config-mirego",
+  "rules": {
+    "selector-pseudo-class-no-unknown": [true, {"ignorePseudoClasses": ["global"]}]
+  }
 }

--- a/app/pods/home/template.hbs
+++ b/app/pods/home/template.hbs
@@ -1,0 +1,9 @@
+{{! template-lint-disable no-bare-strings }}
+
+<div class="home">
+  <a target="_blank" href="https://github.com/mirego/ember-boilerplate" rel="noopener">
+    <img src="https://user-images.githubusercontent.com/11348/51911477-f2b17880-239f-11e9-89aa-8cf94e957155.png" width="600">
+  </a>
+
+  <p>This repository is the stable base upon which we build our Ember.js projects at Mirego.<br>We want to share it with the world so you can build awesome Ember.js applications too.</p>
+</div>

--- a/app/router.ts
+++ b/app/router.ts
@@ -7,6 +7,8 @@ class Router extends EmberRouter {
 }
 
 Router.map(function() {
+  this.route('home', {path: '/'});
+
   // Catch-all error page, put your routes above this one
   this.route('not-found', {path: '/*path'});
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -3,3 +3,18 @@ $color: red;
 h1 {
   color: $color;
 }
+
+:global(.home) {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 40px;
+  text-align: center;
+  line-height: 1.4;
+
+  a {
+    display: block;
+    margin: 0 0 20px;
+  }
+}


### PR DESCRIPTION
Like [we have](https://github.com/mirego/elixir-boilerplate/blob/master/lib/elixir_boilerplate_web/home/templates/index.html.eex) for `elixir-boilerplate`, we now have a home route and template to ensure that booting the project provides a working `200 OK` URL.

<img width="896" alt="" src="https://user-images.githubusercontent.com/11348/56029151-c5f6d700-5ce7-11e9-9b65-bfb17a53b007.png">