### PR TITLE
Add Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.env*
+.git
+node_modules
+build
+dist
+docs
+tmp
+tests

--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -121,3 +121,7 @@ $ ./scripts/ci-check.sh
 ### Versions & branches
 
 Each deployment is made from a Git tag. The codebase version is managed with [`incr`](https://github.com/jcouture/incr).
+
+### Container
+
+A Docker image running a Fastboot-ready Node.js server can be created with `make build`, tested with `make dev-start` and pushed to a registry with `make push`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:10.15-alpine
+
+WORKDIR /opt/app
+
+RUN apk update && \
+    apk upgrade --no-cache && \
+    apk add --no-cache git
+
+COPY package.json package-lock.json ./
+
+COPY scripts ./scripts
+
+RUN npm ci --no-audit --no-color --unsafe-perm
+
+COPY . .
+
+ENTRYPOINT ["./scripts/docker-entrypoint.sh"]

--- a/config/environment.js
+++ b/config/environment.js
@@ -52,7 +52,9 @@ module.exports = function(environment) {
 
   ENV.fastboot = {
     fastbootHeaders: true,
-    hostWhitelist: [process.env.CANONICAL_HOST]
+    hostWhitelist: process.env.CANONICAL_HOST
+      ? [process.env.CANONICAL_HOST]
+      : []
   };
 
   ENV.intl = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.3'
+services:
+  application:
+    image: ember-boilerplate
+    container_name: ember-boilerplate
+    env_file: .env.dev
+    volumes:
+      - '.:/usr/src/app'
+      - '/usr/src/app/node_modules'
+    ports:
+      - '3000:3000'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "server": "npm run enforce-engine-versions && NODE_PATH=$NODE_PATH:. node --optimize_for_size app/server.js",
     "start": "ember server",
     "build": "npm run enforce-engine-versions && ember build",
+    "deploy": "npm run enforce-engine-versions && ember build --prod",
     "enforce-engine-versions": "./scripts/enforce-engine-versions.js",
     "preinstall": "npm run enforce-engine-versions",
     "pretest": "npm run enforce-engine-versions",

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -42,11 +42,17 @@ run make lint-template-lint
 header "Running prettier…"
 run make lint-prettier
 
+header "Build application…"
+run make build-app
+
 header "Running tests…"
 run make test
 
 header "Checking test code coverage…"
 run make test-coverage
+
+header "Build Docker image…"
+run make build
 
 if [ ${error_status} -ne 0 ]; then
   echo "\n\n${YELLOW}▶▶ One of the checks ${RED_BOLD}failed${YELLOW}. Please fix it before committing.${NO_COLOR}"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+npm run deploy
+
+npm run server


### PR DESCRIPTION
The setup is pretty similar to [the one we have](https://github.com/mirego/react-boilerplate/blob/master/Dockerfile) in `react-boilerplate`.

And like in `react-boilerplate`, we need to _build_ the application when _running_ the image, not when _building_ it, because otherwise our setup wouldn’t be twelve-factor-compatible.