### PR TITLE
Suggestion: Add type checking in ci-check script.

### DIFF
--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -45,6 +45,9 @@ run make lint-prettier
 header "Build application…"
 run make build-app
 
+header "Type checking…"
+run make typecheck
+
 header "Running tests…"
 run make test
 


### PR DESCRIPTION
Although building the application perform a type check, the `ci-check` does not fail when type inconsistencies are found.
Running the type check separately ensures that `ci-check` fails when type inconsistencies are found; which is what we want I believe.