### PR TITLE
Improve “make” target naming

### DIFF
--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -27,32 +27,23 @@ header() {
   echo "\n\n${YELLOW}▶ $1${NO_COLOR}"
 }
 
-header "Linting scripts…"
-run make lint-eslint
+header "Lint files…"
+run make lint
 
-header "Linting TypeScript…"
-run make lint-tslint
+header "Check code format…"
+run make check-format
 
-header "Linting stylesheets…"
-run make lint-stylelint
-
-header "Linting templates…"
-run make lint-template-lint
-
-header "Running prettier…"
-run make lint-prettier
+header "Typecheck files…"
+run make check-types
 
 header "Build application…"
 run make build-app
 
-header "Type checking…"
-run make typecheck
-
-header "Running tests…"
+header "Run tests…"
 run make test
 
-header "Checking test code coverage…"
-run make test-coverage
+header "Check test code coverage…"
+run make check-code-coverage
 
 header "Build Docker image…"
 run make build


### PR DESCRIPTION
### Naming convention

* We now use `lint-<stuff>` for targets that lint stuff
* We now use `format-<stuff>` for targets that format or _fix_ stuff
* We now use `check-<stuff>` for targets that check stuff (eg. types, formatting, code coverage, etc.)

### Renaming

* `lint-<tool>` and `format-<tool>` have been converted to `lint-<type>` and `format-<type>` (where `type` is `styles`, `scripts`, etc.)
* `dev-start` and `dev-stop` have been converted to the more accurate `services-start` and `services-stop` because they manage Docker Compose services

### Bonus!

* We now store file patterns as variables at the top of the `Makefile` to make them more visible and prevent them from being hardcoded or duplicated deep down in the file
* Targets are now grouped:
  * Build targets
  * Development targets
  * Check, lint and format targets
  * Service container targets