### PR TITLE
Remove Docker Compose make targets

### DIFF
--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -120,4 +120,4 @@ Each deployment is made from a Git tag. The codebase version is managed with [`i
 
 ### Container
 
-A Docker image running a Fastboot-ready Node.js server can be created with `make build`, tested with `make services-start` and pushed to a registry with `make push`.
+A Docker image running a Fastboot-ready Node.js server can be created with `make build`, tested with `docker-compose up application` and pushed to a registry with `make push`.

--- a/Makefile
+++ b/Makefile
@@ -113,14 +113,3 @@ lint-styles:
 .PHONY: lint-templates
 lint-templates:
 	npx ember-template-lint $(TEMPLATES_PATTERN)
-
-# Service container targets
-# -------------------------
-
-.PHONY: services-start
-services-start: build ## Start every service in the Docker Compose environment
-	docker-compose up
-
-.PHONY: services-stop
-services-stop: ## Stop every service in the Docker Compose environment
-	docker-compose down


### PR DESCRIPTION
We were only making a single reference to the `services-start` target in the README.md — and it was to _test_ the Docker image.

Now we explictely tell developers to use `docker-compose up application` if they want to use Docker Compose to test the image they just built 😄 