### PR TITLE
Fix enforce-engine-version script with node < 10

### DIFF
--- a/scripts/enforce-engine-versions.js
+++ b/scripts/enforce-engine-versions.js
@@ -8,7 +8,7 @@ let semver;
 
 try {
   semver = require('semver');
-} catch {
+} catch (_) {
   // The `semver` might not be available since we run this
   // script as a `preinstall` hook.
   console.info(


### PR DESCRIPTION
## 📖 Description

Under older version of Node (< 10), we were facing a javascript error causing the script to fail instead of reporting the right behavior. Let's fix the Javascript and voila!

```shell
/Users/boubalou/dev/mirego/ember-boilerplate/assets/scripts/enforce-engine-versions.js:11
} catch {
        ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:152:10)
    at Module._compile (module.js:605:28)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Function.Module.runMain (module.js:682:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:613:3
```

After:

```shell
> ./scripts/enforce-engine-versions.js

Node.js 9.2.1
NPM 5.5.1

You are using Node.js 9.2.1 but the required version specified in package.json is ^10.14
You are using NPM 5.5.1 but the required version specified in package.json is ^6.4
```