### PR TITLE
Add usage instructions with GitHub template

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,20 @@ This boilerplate comes with batteries included, you’ll find:
 
 ## Usage
 
+### With GitHub template
+
+1. Click on the [**Use this template**](https://github.com/mirego/ember-boilerplate/generate) button to create a new repository
+2. Clone your newly created project (`git clone https://github.com/you/repo.git`)
+3. Run the boilerplate setup script (`./boilerplate-setup.sh your-project-name`)
+4. Commit the changes (`git commit -a -m "Rename ember-boilerplate parts"`)
+
+### Without GitHub template
+
 1. Clone this project (`git clone https://github.com/mirego/ember-boilerplate.git`)
 2. Delete the internal Git directory (`rm -rf .git`)
-3. Run the project renaming script (`./boilerplate-setup.sh your-project-name`)
-4. Delete the project renaming script (`rm -rf ./boilerplate-setup.sh`)
-5. Create a new Git repository (`git init`)
-6. Create the initial Git commit (`git commit -a -m "Initial commit"`)
+3. Run the boilerplate setup script (`./boilerplate-setup.sh your-project-name`)
+4. Create a new Git repository (`git init`)
+5. Create the initial Git commit (`git commit -a -m "Initial commit"`)
 
 ## License
 


### PR DESCRIPTION
Same as https://github.com/mirego/elixir-boilerplate/pull/56

------

Since the repo is now a ”template” on GitHub, instructions should take advantage of this.

I also updated the _classic_ instructions since they were outdated.