### PR TITLE
Make intl translate optional params really optional

### DIFF
--- a/types/ember-intl/services/intl.d.ts
+++ b/types/ember-intl/services/intl.d.ts
@@ -3,7 +3,7 @@ import IntlService from 'ember-intl/services/intl';
 declare module 'ember-intl/services/intl' {
   export default class IntlService {
     locales: string[];
-    t(translationKey: string, optionalOptions: object, optionalFormats: object): string;
+    t(translationKey: string, optionalOptions?: object, optionalFormats?: object): string;
     exists(translationKey: string, localeName: string): boolean;
     setLocale(localeName: string): void;
     addTranslations(localeName: string, translations: object): object;


### PR DESCRIPTION
### ⚠️ Problem

Ember-intl `t()` current typing force optional parameters

### 👨‍💻 Solution

Fix the function signature.