### PR TITLE
Use ember-cli-babel-polyfills to split Babel polyfills between evergreen and legacy browsers

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -50,6 +50,16 @@ module.exports = function(defaults) {
       includePolyfill: true
     },
 
+    'ember-cli-babel-polyfills': {
+      evergreenTargets: [
+        'last 2 Edge versions',
+        'last 2 Chrome versions',
+        'last 2 Firefox versions',
+        'last 2 Safari versions'
+      ],
+      legacyTargets: ['node 10.15', 'ie 11']
+    },
+
     sourcemaps: {
       enabled: !IS_TEST_ENVIRONMENT
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,6 +1680,14 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
     },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/rsvp": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/rsvp/-/rsvp-4.0.3.tgz",
@@ -6875,6 +6883,75 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz",
       "integrity": "sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA=="
+    },
+    "ember-cli-babel-polyfills": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel-polyfills/-/ember-cli-babel-polyfills-2.0.1.tgz",
+      "integrity": "sha512-NmzraVDWrThvT4ZX7Db3xsKUcvmTOoW4w0lIeY1u4v5uBF8D4v0daMCPlbVHo+TEfzeHHqWvfiy8Foam8AnVng==",
+      "requires": {
+        "broccoli-file-creator": "^2.1.1",
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-persistent-filter": "^2.1.1",
+        "broccoli-rollup": "^2.1.1",
+        "core-js": "^3.2.1",
+        "ember-cli-version-checker": "^3.0.1",
+        "regenerator-runtime": "^0.13.3",
+        "resolve": "^1.11.1",
+        "rollup-plugin-commonjs": "^9.2.0",
+        "rollup-plugin-node-resolve": "^4.0.0"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+          "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw=="
+        },
+        "core-js": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+          "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+        },
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
+          }
+        },
+        "magic-string": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
+          "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        },
+        "rollup-plugin-commonjs": {
+          "version": "9.3.4",
+          "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz",
+          "integrity": "sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==",
+          "requires": {
+            "estree-walker": "^0.6.0",
+            "magic-string": "^0.25.2",
+            "resolve": "^1.10.0",
+            "rollup-pluginutils": "^2.6.0"
+          }
+        },
+        "rollup-plugin-node-resolve": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.4.tgz",
+          "integrity": "sha512-t/64I6l7fZ9BxqD3XlX4ZeO6+5RLKyfpwE2CiPNUKa+GocPlQhf/C208ou8y3AwtNsc6bjSk/8/6y/YAyxCIvw==",
+          "requires": {
+            "@types/resolve": "0.0.8",
+            "builtin-modules": "^3.1.0",
+            "is-module": "^1.0.0",
+            "resolve": "^1.10.0"
+          }
+        }
+      }
     },
     "ember-cli-broccoli-sane-watcher": {
       "version": "3.0.0",
@@ -12606,8 +12683,7 @@
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-      "dev": true
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
     },
     "is-number": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-cli": "github:ember-cli/ember-cli#2ccdc17fd87d7e0cce22aa440e22c00beb72a0ad",
     "ember-cli-autoprefixer": "0.8.1",
     "ember-cli-babel": "7.11.0",
+    "ember-cli-babel-polyfills": "2.0.1",
     "ember-cli-code-coverage": "github:charlesdemers/ember-cli-code-coverage#6961be288d5666e0c8eae4d1988bbfac3773b433",
     "ember-cli-content-security-policy": "1.1.1",
     "ember-cli-dependency-checker": "3.2.0",


### PR DESCRIPTION
Since evergreen browsers need much less polyfilling than IE11, we use `ember-cli-babel-polyfills` to split them in 3 bundles: 

1. evergreen
2. legacy
3. shared

Loading of the bundles is handled by the `nomodule` flag, it makes sure we load the legacy bundle only in browsers that don’t support native JavaScript modules.

<img width="486" alt="Screen Shot 2019-09-09 at 7 50 42 PM" src="https://user-images.githubusercontent.com/425073/64573918-25aaea00-d33b-11e9-943d-08fe52a2225b.png">
