### PR TITLE
Fix SVG file presence check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,10 @@ check-code-coverage:
 .PHONY: format
 format: ## Format project files
 	- npx prettier --write $(PRETTIER_FILES_PATTERN)
-	- count=`ls -1 ./public/**/*.svg 2>/dev/null | wc -l` ; \
-    if [ $$count != 0 ] ; then \
-      npx svgo --config=.svgo.yml --recursive --folder ./public ; \
-    fi;
+	- count=`find ./public/ -type f -name '*.svg' | wc -l` ; \
+		if [ $$count != 0 ] ; then \
+			npx svgo --config=.svgo.yml --recursive --folder ./public ; \
+		fi;
 
 .PHONY: lint
 lint: lint-scripts lint-styles lint-templates ## Lint project files


### PR DESCRIPTION
The check to see if SVG files are present never returned `true`, now it does!