### PR TITLE
Fix middleware URL parsing

### DIFF
--- a/node-server/middleware/deduplicate-slashes.js
+++ b/node-server/middleware/deduplicate-slashes.js
@@ -5,9 +5,13 @@ const url = require('url');
 
 // Constants
 const PERMANENT_REDIRECT_STATUS_CODE = 301;
+const canonicalHost = process.env.CANONICAL_HOST;
 
 module.exports = (request, response, next) => {
-  const parsedUrl = new URL(request.url);
+  const parsedUrl = new URL(
+    request.url,
+    `${request.protocol}://${canonicalHost}`
+  );
 
   if (!parsedUrl.pathname.match(/\/{2,}/)) return next();
 

--- a/node-server/middleware/strip-trailing-slashes.js
+++ b/node-server/middleware/strip-trailing-slashes.js
@@ -5,9 +5,13 @@ const url = require('url');
 
 // Constants
 const PERMANENT_REDIRECT_STATUS_CODE = 301;
+const canonicalHost = process.env.CANONICAL_HOST;
 
 module.exports = (request, response, next) => {
-  const parsedUrl = new URL(request.url);
+  const parsedUrl = new URL(
+    request.url,
+    `${request.protocol}://${canonicalHost}`
+  );
 
   if (!parsedUrl.pathname.match(/^.+\/$/)) return next();
 


### PR DESCRIPTION
The `URL` constructor expects a complete URL or a relative URL with a base URL, since we were passing only the relative part, it was throwing an error. Now we make sure to pass the base URL