### PR TITLE
Fix health check sending headers after body

### DIFF
--- a/node-server/server.js
+++ b/node-server/server.js
@@ -54,8 +54,7 @@ if (process.env.SENTRY_DSN) {
 
 // Health check
 app.get('/health', (_, response) => {
-  response.send({status: 'OK', version: PACKAGE.version});
-  response.sendStatus(OK_HTTP_CODE);
+  response.status(OK_HTTP_CODE).send({status: 'OK', version: PACKAGE.version});
 });
 
 // Canonical host


### PR DESCRIPTION
The health check was working but always throwing an error due to the fact that we trying to set the status code after sending the body of the response.