### PR TITLE
Do not cache invalid network responses when using service worker

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -121,6 +121,8 @@ const cacheFirst = (request, cacheName) => {
         if (response) return response;
 
         return fetch(request).then(networkResponse => {
+          if (!networkResponse.ok) return networkResponse;
+
           cache.put(request, networkResponse.clone());
 
           return networkResponse;
@@ -140,6 +142,8 @@ const networkFirst = (
     .open(cacheName)
     .then(cache => {
       const networkPromise = fetch(request).then(response => {
+        if(!response.ok) return response;
+
         cache.put(request, response.clone());
 
         return response;

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -142,7 +142,7 @@ const networkFirst = (
     .open(cacheName)
     .then(cache => {
       const networkPromise = fetch(request).then(response => {
-        if(!response.ok) return response;
+        if (!response.ok) return response;
 
         cache.put(request, response.clone());
 


### PR DESCRIPTION
We were putting in service worker cache invalid responses in `cacheFirst` and `networkFirst` strategies. This resulted in invalid responses or errors being served to the user over and over again even if the problem was fixed on remote.

This PR fixes this issue by checking that the response is successful before caching it