### PR TITLE
Fix Sentry integration

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const PACKAGE = require('../package.json');
-const {asBoolean} = require('./utils');
+const {asBoolean, isPresent} = require('./utils');
 
 // This function is used to build an `ENV` variable from environment variables
 // when running `ember build`. This variable will be injected into the browser
@@ -64,11 +64,15 @@ module.exports = function(environment) {
   };
 
   ENV.sentry = {
-    enabled: asBoolean(process.env.SENTRY_DSN),
+    enabled: isPresent(process.env.SENTRY_DSN),
     dsn: process.env.SENTRY_DSN,
     environment: process.env.SENTRY_ENVIRONMENT_NAME,
     release: PACKAGE.version,
-    whitelistUrls: [process.env.ASSETS_CDN_HOST || process.env.CANONICAL_HOST],
+    whitelistUrls: [
+      process.env.ASSETS_CDN_PROTOCOL && process.env.ASSETS_CDN_HOST
+        ? `${process.env.ASSETS_CDN_PROTOCOL}://${process.env.ASSETS_CDN_HOST}`
+        : process.env.CANONICAL_HOST
+    ],
     debug: process.env.NODE_ENV !== 'production'
   };
 

--- a/config/utils.js
+++ b/config/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  isPresent: variable => Boolean(variable),
   asBoolean: variable => ['true', '1'].includes(variable),
   asInteger: variable => parseInt(variable, 10)
 };

--- a/node-server/server.js
+++ b/node-server/server.js
@@ -18,7 +18,7 @@ const stripTrailingSlashes = require('./middleware/strip-trailing-slashes');
 const deduplicateSlashes = require('./middleware/deduplicate-slashes');
 
 // Utils
-const {asBoolean, asInteger} = require('../config/utils');
+const {asBoolean, asInteger, isPresent} = require('../config/utils');
 const PACKAGE = require('../package.json');
 
 // Constants
@@ -35,7 +35,7 @@ const BASIC_AUTH_OPTIONS = {
 // Server
 const httpServer = new HTTPServer({
   afterMiddleware(app) {
-    if (process.env.SENTRY_DSN) {
+    if (isPresent(process.env.SENTRY_DSN)) {
       app.use(Sentry.Handlers.errorHandler());
     }
 
@@ -46,8 +46,8 @@ const httpServer = new HTTPServer({
 const app = httpServer.app;
 
 // Sentry
-if (process.env.SENTRY_DSN) {
-  Sentry.init({dsn: process.env.SENTRY_DSN});
+if (isPresent(process.env.SENTRY_DSN)) {
+  Sentry.init(config(process.env.NODE_ENV).sentry);
 
   app.use(Sentry.Handlers.requestHandler());
 }


### PR DESCRIPTION
The integration didn’t work because of a little mistake from me: `asBoolean` only accepts "boolean" values, it doesn’t cast another type 😬 

So now, I added another utils for that case and we use it for activating Sentry