### PR TITLE
Bring back improvements from client project

### DIFF
--- a/app/pods/not-found/route.ts
+++ b/app/pods/not-found/route.ts
@@ -1,0 +1,17 @@
+// Vendor
+import Route from '@ember/routing/route';
+import {inject as service} from '@ember/service';
+
+// Types
+import FastBoot from 'ember-cli-fastboot/services/fastboot';
+
+export default class NotFound extends Route {
+  @service('fastboot')
+  fastboot: FastBoot;
+
+  beforeModel() {
+    if (!this.fastboot.isFastBoot) return;
+
+    this.fastboot.response.statusCode = 404;
+  }
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -37,15 +37,18 @@ module.exports = function(environment) {
     SSR_CACHE_KEY: 'apollo-cache'
   };
 
+  let scriptSources = ["'self'"];
+
+  if (environment !== 'production') {
+    scriptSources = ["'unsafe-inline'", "'unsafe-eval'", ...scriptSources];
+  }
+
   ENV.contentSecurityPolicy = {
     'default-src': "'none'",
     'form-action': "'self'",
     'media-src': "'self'",
     'img-src': ["'self'", 'data:'],
-    'script-src':
-      environment === 'production'
-        ? ["'self'"]
-        : ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+    'script-src': scriptSources,
     'font-src': ["'self'"],
     'connect-src': ["'self'", 'https://sentry.io', process.env.API_BASE_URL],
     'style-src': ["'self'"]

--- a/config/utils.js
+++ b/config/utils.js
@@ -3,5 +3,6 @@
 module.exports = {
   isPresent: variable => Boolean(variable),
   asBoolean: variable => ['true', '1'].includes(variable),
-  asInteger: variable => parseInt(variable, 10)
+  asInteger: variable => parseInt(variable, 10),
+  asArray: variable => (Array.isArray(variable) ? variable.split(',') : [])
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -24,6 +24,10 @@ module.exports = function(defaults) {
       'jquery.js': null
     },
 
+    autoImport: {
+      exclude: ['graphql-tag']
+    },
+
     // SCSS compilation
     autoprefixer: {
       browsers: targets.browsers,
@@ -42,10 +46,6 @@ module.exports = function(defaults) {
     babel: {
       plugins: ['graphql-tag', require('ember-auto-import/babel-plugin')],
       sourceMaps: 'inline'
-    },
-
-    'ember-cli-babel': {
-      includePolyfill: true
     },
 
     'ember-cli-babel-polyfills': {


### PR DESCRIPTION
1. Set the status code correctly on the 404 page
2. Remove `graphql-tag` from the final bundle since GraphQL queries are precompiled and don’t need `graphql-tag` at runtime
3. Remove Babel config to add polyfills, it’s already taken care of by `ember-cli-babel-polyfills`
4. Make sure to never cache `/health`, `/robots.txt`, `sitemap.xml`, `/sw.js`
5. Use `cacheControl` middleware to cache assets