### PR TITLE
Update the i18n routing documentation concerning the Router's dslCallbacks array

### DIFF
--- a/docs/i18n-routing.md
+++ b/docs/i18n-routing.md
@@ -59,7 +59,7 @@ La solution est donc de sortir la définition des routes de la phase de définit
    };
    ```
 
-2. On assigne les routes à notre instance avec la langue qu’on a assigné plus haut
+2. On assigne les routes à notre instance avec la langue qu’on a assigné plus haut en s'assurant de réinitialiser l'_array_ `Router.dslCallbacks` afin d'éviter une potentielle fuite de mémoire.
 
    ```js
    // app/instance-initializers/translated-routes.js
@@ -67,6 +67,8 @@ La solution est donc de sortir la définition des routes de la phase de définit
    export const initialize = instance => {
      const intl = instance.lookup('service:intl');
      const Router = instance.router.constructor;
+
+     Router.dslCallbacks = [];
 
      Router.map(function() {
        this.route('hello', {path: intl.t('routes.hello')});


### PR DESCRIPTION
The `Router`'s `dslCallbacks` array could cause memory leaks in applications.

We have to empty the `dslCallbacks` array from the `Router` in order to prevent memory leaks. Ember pushes all the routes into the `dslCallbacks` array every time this initializer is called. This can cause a memory leak since `dslCallbacks` is a global variable of `Router`.

See https://github.com/emberjs/ember.js/blob/d96d9aad52e010da977d813f479494397ee53ec6/packages/%40ember/-internals/routing/lib/system/router.ts#L1556.
