### PR TITLE
Fix Makefile output of the different targets when using numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `master` branch should always be stable and usable.
 
+## 2020-03-18
+
+### Fixed
+
+- Makefile (`Makefile`) output of the different targets when using numbers
+
 ## 2020-02-21
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ header:
 targets:
 	@echo "\033[34mTargets\033[0m"
 	@echo "\033[34m---------------------------------------------------------------\033[0m"
-	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+	@perl -nle'print $& if m{^[a-zA-Z_-\d]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
 
 # Build targets
 # -------------


### PR DESCRIPTION
## 📖 Description

Fix the Makefile parsing regex to support numbers when listing the different targets. 

## 🦀 Dispatch
		
- `#dispatch/devops`

## 🎉 Résultat

| Avant | Après |
| ------ | ------ |
| ![Screen Shot 2020-03-18 at 12 04 01](https://user-images.githubusercontent.com/513491/76982758-b548db00-6912-11ea-93da-8cf33e1e4c5b.png) | ![Screen Shot 2020-03-18 at 12 03 47](https://user-images.githubusercontent.com/513491/76982756-b4b04480-6912-11ea-88a7-5adf2ab54fa8.png)  |

