### PR TITLE
Init chai dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2929,6 +2929,15 @@
       "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
       "dev": true
     },
+    "@types/chai-dom": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai-dom/-/chai-dom-0.0.10.tgz",
+      "integrity": "sha512-C5M5ht5visUd0fEB+drAL4IoqhPZnF9Ts9N+FnRU+IdxHHNGzeqquEtdhZAjLi0t4uzKnqS5lU2SuTwG9d6+8w==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -3349,6 +3358,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-background-sync/-/workbox-background-sync-4.3.0.tgz",
       "integrity": "sha512-3gter5CYDlJk2eHohMdl/s9IKjdRzUw5EN6J2wxvmwFu4Sy+OIqvPFKrDy5DMmtHCVlQbEJFGk8xJf2OOQvjNQ==",
+      "dev": true,
       "requires": {
         "@types/workbox-core": "*"
       }
@@ -3357,6 +3367,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-broadcast-update/-/workbox-broadcast-update-4.3.0.tgz",
       "integrity": "sha512-YSaXuGLknt1Apl/fZUMAB9BwKqpzZCi/HmpSJ/McTM9UihXzz+MFbv5Pxy+hFhKnu/YFxblAZvH6x2pOeylJFA==",
+      "dev": true,
       "requires": {
         "@types/workbox-core": "*"
       }
@@ -3365,6 +3376,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-cacheable-response/-/workbox-cacheable-response-4.3.0.tgz",
       "integrity": "sha512-zY6dLWlmbIf6mQvUOR8qD8gz2EfmJ+/KjGQl/NMcsk3OBwLGCRnxVlOAiUrFsHRZSnUMo6gip1lwLOEvUjPIRQ==",
+      "dev": true,
       "requires": {
         "@types/workbox-core": "*"
       }
@@ -3372,12 +3384,14 @@
     "@types/workbox-core": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-core/-/workbox-core-4.3.0.tgz",
-      "integrity": "sha512-0Tn2bbwYu+Exsp4L3lBA2voRi/7m+6qjgGIs4Lw3Hdm8+7caxAVRra6imkd9Wl3DmK0tKPHinKuo+ElXuqUvlg=="
+      "integrity": "sha512-0Tn2bbwYu+Exsp4L3lBA2voRi/7m+6qjgGIs4Lw3Hdm8+7caxAVRra6imkd9Wl3DmK0tKPHinKuo+ElXuqUvlg==",
+      "dev": true
     },
     "@types/workbox-expiration": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-expiration/-/workbox-expiration-4.3.0.tgz",
       "integrity": "sha512-fxPC5w+LNAn6ddQXKe84j9+C7bwNcMplw/QvnHjzAuTFW/oHC/8geHKTs4aoIMjUdRJrtFND5/lthivBynWwJw==",
+      "dev": true,
       "requires": {
         "@types/workbox-core": "*"
       }
@@ -3385,17 +3399,20 @@
     "@types/workbox-google-analytics": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-google-analytics/-/workbox-google-analytics-4.3.0.tgz",
-      "integrity": "sha512-0XEhUYRh4WLVKYkGaLZhwM7rDZjy2RqxYfJr2b7OuRLadRgiK2XPso1uwGi1l4oXqlt8Ya3alyFDfKt54pm3QQ=="
+      "integrity": "sha512-0XEhUYRh4WLVKYkGaLZhwM7rDZjy2RqxYfJr2b7OuRLadRgiK2XPso1uwGi1l4oXqlt8Ya3alyFDfKt54pm3QQ==",
+      "dev": true
     },
     "@types/workbox-navigation-preload": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-navigation-preload/-/workbox-navigation-preload-4.3.0.tgz",
-      "integrity": "sha512-yv4iMch2cM1rW2GTFjtEHAmUJfYtWnHENdR9TrjziO47czDSulLU/UzflmS/L9alQNP7GyHpegDWBJwtKad/Mg=="
+      "integrity": "sha512-yv4iMch2cM1rW2GTFjtEHAmUJfYtWnHENdR9TrjziO47czDSulLU/UzflmS/L9alQNP7GyHpegDWBJwtKad/Mg==",
+      "dev": true
     },
     "@types/workbox-precaching": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-precaching/-/workbox-precaching-4.3.0.tgz",
       "integrity": "sha512-nnnFemK7X6kfJi7u3cZ2qkHCsWFJn+AUtBgBb8UJB7VxongJsBK/QTVbmMGhvIXBb/xkRpoa52VI2rtZLoB3hA==",
+      "dev": true,
       "requires": {
         "@types/workbox-core": "*"
       }
@@ -3404,6 +3421,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-range-requests/-/workbox-range-requests-4.3.0.tgz",
       "integrity": "sha512-IlZcWZtGlpT4OhEdCdWeMkHHOO5yVwDqmuJq1WtgtjyIwm/mwwVPYGLVeVOE62m8sQ2L9Ziqfem2h9UmabBDmg==",
+      "dev": true,
       "requires": {
         "@types/workbox-core": "*"
       }
@@ -3411,12 +3429,14 @@
     "@types/workbox-routing": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-routing/-/workbox-routing-4.3.0.tgz",
-      "integrity": "sha512-op5P/f6n+9g5X4a+sYONp9EALnNxpoU3oXuB/BjeQv9d+k0bNE4LYSF06K6tXYL4PeCIZVJOi4yMCUCOi2NaqQ=="
+      "integrity": "sha512-op5P/f6n+9g5X4a+sYONp9EALnNxpoU3oXuB/BjeQv9d+k0bNE4LYSF06K6tXYL4PeCIZVJOi4yMCUCOi2NaqQ==",
+      "dev": true
     },
     "@types/workbox-strategies": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-strategies/-/workbox-strategies-4.3.0.tgz",
       "integrity": "sha512-QTQQOZK2qNy24jXLt83SlqEmuEaQcubQ23515OFDBUpyVow2cYpxF2vzH3fEx7kIXQO/OS1UFNriTEitCHyxyA==",
+      "dev": true,
       "requires": {
         "@types/workbox-core": "*",
         "@types/workbox-routing": "*"
@@ -3426,6 +3446,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-streams/-/workbox-streams-4.3.0.tgz",
       "integrity": "sha512-PYI7eAOQ9Dj/cu/WcROOfSsn29pC9gjCudK+hQBSWgAaxfHBmNFQGh7EvtZ3BzOJhjj3O0pEV5l6aA55oBRxBQ==",
+      "dev": true,
       "requires": {
         "@types/workbox-routing": "*"
       }
@@ -3434,6 +3455,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/workbox-sw/-/workbox-sw-4.3.0.tgz",
       "integrity": "sha512-PX4CQq+MH1ET94o6AE5GsLQ57WznWFC8eoXYIRUKv4vSFQFRDmlSRRonyFHlcdNhE9skKJBjxapUt4PPit0L1g==",
+      "dev": true,
       "requires": {
         "@types/workbox-background-sync": "*",
         "@types/workbox-broadcast-update": "*",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "devDependencies": {
     "@types/chai": "4.2.7",
+    "@types/chai-dom": "0.0.10",
     "@types/ember": "3.1.1",
     "@types/ember-mocha": "0.14.8",
     "@types/ember-test-helpers": "1.0.6",

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,8 +4,10 @@ import {setApplication} from '@ember/test-helpers';
 import start from 'ember-exam/test-support/start';
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
+import chaiDom from 'chai-dom';
 
 chai.use(sinonChai);
+chai.use(chaiDom);
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
### ⚠️ Problem

The `chai-dom` package is currently installed in the boilerplate but it is not properly hooked to the test setup.

### 👨‍💻 Solution

- Include it in the `test-helper.js`, just like we did for `sinon-chai`
- Install the types since `chai-dom` does not ship with its typings