### PR TITLE
Add an eslint rule to escape unused variables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,7 +71,10 @@ module.exports = {
         '@typescript-eslint/type-annotation-spacing': 2,
         '@typescript-eslint/unified-signatures': 2,
         'no-unused-vars': 0,
-        '@typescript-eslint/no-unused-vars': 2
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {argsIgnorePattern: '^_', varsIgnorePattern: '^_'}
+        ]
       }
     },
     {


### PR DESCRIPTION
### 🐛 Problem

With the previous configuration, we could not escape unused params and variables, which is sometime required when using positional params and arrays.

### 💊 Solution

It is widely accepted that `_` prefixed variables are not used.
