### PR TITLE
Add explicit Dispatch stack in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,7 @@
 ## 📓 References
 
 <!-- Does this pull request fix any reported issue (eg. `Fixes #34`) in this repository? -->
+
+## 🦀 Dispatch
+
+- `#dispatch/ember`


### PR DESCRIPTION
## 📖 Description

Instead of configuring stacks _per project_ in the Dispatch webhook, we want them to be specified _per pull request_.

This ensures the requested stacks are explicit and not implicit. This also allows to be easily reminded that `#dispatch/none` is sometimes a good option 😉 

## 🦀 Dispatch

- `#dispatch/none`