### PR TITLE
Fix the "forcedomain" require instruction in server.js

### DIFF
--- a/node-server/server.js
+++ b/node-server/server.js
@@ -7,7 +7,7 @@ const basicAuth = require('express-basic-auth');
 const config = require('../config/environment');
 const compression = require('compression');
 const forceSSL = require('express-force-ssl');
-const forceDomain = require('forcedomain');
+const {forceDomain} = require('forcedomain');
 const cacheControl = require('express-cache-controller');
 
 // Custom HTTP Server


### PR DESCRIPTION
## 📖 Description

Since the version `2.1.0` of [`forcedomain`](https://github.com/thenativeweb/forcedomain), the main export is no longer a default export, but a named export.

We fix our `node_module/server.js` file to reflect this change and fix the build script!

## 🦀 Dispatch

- `#dispatch/ember`
