### PR TITLE
Update Sentry setup

### DIFF
--- a/app/initializers/sentry.ts
+++ b/app/initializers/sentry.ts
@@ -1,13 +1,9 @@
-import * as Sentry from '@sentry/browser';
-import {Ember} from '@sentry/integrations/esm/ember';
-import config from 'ember-boilerplate/config/environment';
+import {InitSentryForEmber} from '@sentry/ember';
+import {Event, EventHint} from '@sentry/types';
 
 export const initialize = () => {
-  Sentry.init({
-    ...config.sentry,
-    integrations: [new Ember()],
-
-    beforeSend(event, hint) {
+  InitSentryForEmber({
+    beforeSend(event: Event, hint: EventHint) {
       const error = hint?.originalException;
 
       if (typeof error !== 'object') return event;

--- a/app/services/-apollo.ts
+++ b/app/services/-apollo.ts
@@ -5,7 +5,7 @@ import {createHttpLink} from '@apollo/client/core';
 import {onError} from '@apollo/client/link/error';
 import {inject as service} from '@ember/service';
 import ApolloService from 'ember-apollo-client/services/apollo';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/ember';
 import fetch from 'fetch';
 
 // Types

--- a/config/environment.js
+++ b/config/environment.js
@@ -64,17 +64,22 @@ module.exports = function (environment) {
     TRANSLATIONS_CACHE_KEY: 'translations',
   };
 
-  ENV.sentry = {
-    enabled: isPresent(process.env.SENTRY_DSN),
-    dsn: process.env.SENTRY_DSN,
-    environment: process.env.SENTRY_ENVIRONMENT_NAME,
-    release: appPackage.version,
-    whitelistUrls: [
-      process.env.ASSETS_CDN_PROTOCOL && process.env.ASSETS_CDN_HOST
-        ? `${process.env.ASSETS_CDN_PROTOCOL}://${process.env.ASSETS_CDN_HOST}`
-        : process.env.CANONICAL_HOST,
-    ],
-    debug: process.env.NODE_ENV !== 'production',
+  ENV['@sentry/ember'] = {
+    ignoreEmberOnErrorWarning: true,
+    disablePerformance: true,
+    disableInstrumentComponents: true,
+    disableRunloopPerformance: true,
+    sentry: {
+      allowUrls: [
+        process.env.ASSETS_CDN_PROTOCOL && process.env.ASSETS_CDN_HOST
+          ? `${process.env.ASSETS_CDN_PROTOCOL}://${process.env.ASSETS_CDN_HOST}`
+          : process.env.CANONICAL_HOST,
+      ],
+      debug: process.env.NODE_ENV !== 'production',
+      dsn: process.env.SENTRY_DSN,
+      environment: process.env.SENTRY_ENVIRONMENT_NAME,
+      release: `ember-boilerplate@${appPackage.version}`,
+    },
   };
 
   if (environment === 'test') {

--- a/types/@sentry/ember/index.d.ts
+++ b/types/@sentry/ember/index.d.ts
@@ -1,0 +1,5 @@
+declare module '@sentry/ember' {
+  import {BrowserOptions} from '@sentry/browser';
+  export function InitSentryForEmber(_runtimeConfig: BrowserOptions): void;
+  export * from '@sentry/browser';
+}


### PR DESCRIPTION
## 📖 Description

The new `@sentry/ember` addon is only compatible with Embroider, now that we have it we can update our setup! 🎉 

## 🦀 Dispatch

- `#dispatch/ember`
