### PR TITLE
Fix async translations setup

### DIFF
--- a/app/services/translations.ts
+++ b/app/services/translations.ts
@@ -11,7 +11,7 @@ import config from 'ember-boilerplate/config/environment';
 export type AvailableLocale = 'en-ca';
 
 const pathForLocale: Record<AvailableLocale, string> = {
-  'en-ca': '/assets/translations/en-ca.json',
+  'en-ca': '/translations/en-ca.json',
 };
 
 export default class Translations extends Service {
@@ -37,7 +37,7 @@ export default class Translations extends Service {
 
     const translations = this.fetchTranslationsFromShoebox(locale);
 
-    if (translations) return translations;
+    if (Object.keys(translations).length > 0) return translations;
 
     return this.fetchTranslationsFromNetwork(locale);
   }
@@ -65,6 +65,6 @@ export default class Translations extends Service {
 
 declare module '@ember/service' {
   interface Registry {
-    translations: Account;
+    translations: Translations;
   }
 }

--- a/tests/unit/services/translations-test.ts
+++ b/tests/unit/services/translations-test.ts
@@ -27,7 +27,7 @@ describe('Unit | Services | Translations', function () {
     service = this.owner.lookup('service:translations');
 
     server = new Pretender(function () {
-      this.get('/assets/translations/en-ca.json', () => {
+      this.get('/translations/en-ca.json', () => {
         return [200, {'Content-Type': 'application/json'}, '{"foo":"bar"}'];
       });
     }) as PretenderWithHandlers;
@@ -104,7 +104,7 @@ describe('Unit | Services | Translations', function () {
           this.owner.register('service:fastboot', FastBootStub);
 
           class ShoeboxStub extends Service {
-            read = sinon.stub().returns(null);
+            read = sinon.stub().returns({});
             write = sinon.stub();
           }
 


### PR DESCRIPTION
## 📖 Description

After testing the async translations setup in a real app I found out that the translation files were placed at the root instead of in the assets folder. I also fixed how we check for the translations presence since the shoebox always returns an object, not null.

## 🦀 Dispatch

- `#dispatch/ember`
