### PR TITLE
Update `FastbootLocation` service

### DIFF
--- a/app/services/location/fastboot.ts
+++ b/app/services/location/fastboot.ts
@@ -29,7 +29,7 @@ export default class FastBootLocation extends Service implements LocationInterfa
 
     const endIndex = Math.min(queryIndex, hashIndex);
 
-    return pathWithQuery.slice(0, endIndex >= 0 ? endIndex : 0);
+    return queryIndex >= 0 ? pathWithQuery.slice(0, endIndex >= 0 ? endIndex : 0) : pathWithQuery;
   }
 
   get queryString(): string {

--- a/tests/unit/services/location/fastboot-test.ts
+++ b/tests/unit/services/location/fastboot-test.ts
@@ -92,7 +92,7 @@ describe('Unit | Services | Location | Fastboot', () => {
           isFastBoot = true;
           request = {
             host: 'www.mirego.com',
-            path: '#foo',
+            path: '',
           };
         }
 


### PR DESCRIPTION
## 📖 Description

Update FastBoot location service to ensure that `path` is returning a value even if there is no query/hash in the URL.

With the actual code, `location.path` returns an empty string even if the URL is `localhost:4200/en`.

## 🦀 Dispatch

- `#dispatch/ember`
