### PR TITLE
Fix bugs in FastBootLocation path and queryString methods

### DIFF
--- a/app/services/location/fastboot.ts
+++ b/app/services/location/fastboot.ts
@@ -25,7 +25,7 @@ export default class FastBootLocation extends Service implements LocationInterfa
   get path(): string {
     const pathWithQuery = this.fastboot.request.path;
     const queryIndex = pathWithQuery.indexOf('?');
-    const hashIndex = pathWithQuery.indexOf('#', queryIndex);
+    const hashIndex = pathWithQuery.includes('#') ? pathWithQuery.indexOf('#') : queryIndex;
 
     const endIndex = Math.min(queryIndex, hashIndex);
 
@@ -35,7 +35,7 @@ export default class FastBootLocation extends Service implements LocationInterfa
   get queryString(): string {
     const pathWithQuery = this.fastboot.request.path;
     const queryIndex = pathWithQuery.indexOf('?');
-    const hashIndex = pathWithQuery.indexOf('#', queryIndex);
+    const hashIndex = pathWithQuery.includes('#') ? pathWithQuery.indexOf('#') : Infinity;
 
     return queryIndex >= 0 ? pathWithQuery.slice(queryIndex, hashIndex) : '';
   }

--- a/tests/unit/services/location/fastboot-test.ts
+++ b/tests/unit/services/location/fastboot-test.ts
@@ -86,6 +86,24 @@ describe('Unit | Services | Location | Fastboot', () => {
       });
     });
 
+    describe('when a path is present but no hash', () => {
+      beforeEach(function () {
+        class FastBootStub extends Service {
+          isFastBoot = true;
+          request = {
+            host: 'www.mirego.com',
+            path: '/foo-bar?foo=bar',
+          };
+        }
+
+        this.owner.register('service:fastboot', FastBootStub);
+      });
+
+      it('should return the request path', () => {
+        expect(service.path).to.equal('/foo-bar');
+      });
+    });
+
     describe('when no path is present', () => {
       beforeEach(function () {
         class FastBootStub extends Service {
@@ -151,6 +169,24 @@ describe('Unit | Services | Location | Fastboot', () => {
           request = {
             host: 'www.mirego.com',
             path: '/foo-bar?foo=bar#foo',
+          };
+        }
+
+        this.owner.register('service:fastboot', FastBootStub);
+      });
+
+      it('should return the queryString', () => {
+        expect(service.queryString).to.equal('?foo=bar');
+      });
+    });
+
+    describe('when a queryString is present but no hash', () => {
+      beforeEach(function () {
+        class FastBootStub extends Service {
+          isFastBoot = true;
+          request = {
+            host: 'www.mirego.com',
+            path: '/foo-bar?foo=bar',
           };
         }
 


### PR DESCRIPTION
## 📖 Description

There was a bug in both `path` and `queryString` methods for `FastBootLocation` where we assumed that a `#hash` would be present. I added a test for both methods and fixed the bug!

## 🦀 Dispatch

- `#dispatch/ember`
